### PR TITLE
Update BSD-2-Clause-FreeBSD.html

### DIFF
--- a/rdfa/BSD-2-Clause-FreeBSD.html
+++ b/rdfa/BSD-2-Clause-FreeBSD.html
@@ -160,7 +160,7 @@
       </div>
       
 <div class="replacable-license-text">
-         <p>Copyright 1992-2012 The FreeBSD Project. All rights reserved.</p>
+         <p>Copyright 1992-2012 The FreeBSD Project.</p>
 
       </div>
 
@@ -191,12 +191,7 @@
          INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
          TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
          ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-
-      <p>The views and conclusions contained in the software and documentation are those of the authors and should
-         not be interpreted as representing official policies, either expressed or implied, of the FreeBSD
-         Project.</p>
-
-    
+ 
       </div>
 
       <h2  id="licenseHeader">Standard License Header</h2>


### PR DESCRIPTION
- "All rights reserved." is considered obsolete.

- What appears to be a final disclaimer is not part of the license (and has never been used in code). It was a disclaimer from the FreeBSD Documentation Project that was bogusly copied by some sites, including OSI, but that has slowly been fixed.
For further reference, check
https://www.freebsd.org/doc/en_US.ISO8859-1/articles/committers-guide/pref-license.html