### PR TITLE
Zlib license template indentation

### DIFF
--- a/text/Zlib.txt
+++ b/text/Zlib.txt
@@ -1,4 +1,6 @@
-zlib License Copyright (c) <year> <copyright holders>
+zlib License
+
+Copyright (c) <year> <copyright holders>
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the
@@ -16,4 +18,4 @@ not required.
 2. Altered source versions must be plainly marked as such, and must not be
 misrepresented as being the original software.
 
-   3. This notice may not be removed or altered from any source distribution.
+3. This notice may not be removed or altered from any source distribution.

--- a/text/zlib-acknowledgement.txt
+++ b/text/zlib-acknowledgement.txt
@@ -23,4 +23,4 @@ Philip A. Craig
 2. Altered source versions must be plainly marked as such, and must not be
 misrepresented as being the original software.
 
-   3. This notice may not be removed or altered from any source distribution.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
Reference: https://github.com/go-gitea/gitea/pull/12781

I come to contact with zlib license frequently. This change is pretty much a non-issue but it bothered me every time I had to edit indentation when creating new LICENSE file (related to Gitea project - see reference above). I verified this change with resources from links below. I don't believe there is any valid reason for those 3 spaces; and initial line in case of zlib license template file itself.

https://en.wikipedia.org/wiki/Zlib_License
https://opensource.org/licenses/Zlib