### PR TITLE
Add NCUL-1.0 — Non-Corporate Use License

### DIFF
--- a/json/details/NCUL-1.0.json
+++ b/json/details/NCUL-1.0.json
@@ -1,0 +1,15 @@
+{
+  "licenseListVersion": "3.20",
+  "name": "Non-Corporate Use License",
+  "licenseId": "NCUL-1.0",
+  "seeAlso": [
+    "https://example.local/LICENSE-NONCORP.txt"
+  ],
+  "isOsiApproved": false,
+  "isDeprecatedLicenseId": false,
+  "detailsUrl": "https://example.local/spdx/NCUL-1.0.json",
+  "isFsfLibre": false,
+  "standardLicenseHeader": "",
+  "standardLicenseTemplate": "",
+  "notes": "Custom license restricting corporate use. Not OSI-approved."
+}

--- a/src/NCUL-1.0.txt
+++ b/src/NCUL-1.0.txt
@@ -1,0 +1,24 @@
+Non-Corporate Use License (NCUL-1.0)
+
+Copyright (c) 2026 The Authors
+
+Permission is hereby granted, free of charge, to any natural person or non-profit community project ("Individual Users") to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, subject to the following conditions:
+
+1. Corporate Use Prohibited: "Corporate Use" — defined as use by or for the primary benefit of any for-profit entity, including but not limited to companies with shareholders, paid employees on a payroll, or explicit profit motive — is strictly prohibited. This includes using the Software in any product, service, infrastructure, internal tooling, or other activity that directly supports a for-profit organization's operations or revenue generation.
+
+2. Attribution: Redistributions of the Software in source or binary form must retain this copyright notice and the above permission notice.
+
+3. No Warranty: The Software is provided "AS IS", without warranty of any kind, express or implied. The authors are not liable for any claims, damages, or other liabilities arising from its use.
+
+4. Termination: Any attempt to circumvent this license or use the Software for Corporate Use automatically terminates the license granted to the offending party.
+
+For questions regarding whether a particular use counts as "Corporate Use", contact the maintainers. This license does not constitute legal advice.
+
+SPDX-License-Identifier: NCUL-1.0
+
+Scope and Compatibility:
+
+- This license applies only to files and code that are owned by the copyright holders of this project and to which they have the authority to apply this license. It does NOT relicense third-party components included in this repository.
+- Third-party components retain their original licenses (for example: MIT, BSD, Apache-2.0, MPL, GPL, etc.). You must comply with those licenses when using or redistributing those components.
+- Copyleft licenses (GPL, AGPL, MPL, LGPL and similar) often prohibit adding further restrictions on the recipient's rights for the covered code. Therefore, the NCUL-1.0 cannot be used to impose additional restrictions on third-party copyleft components. If this repository includes such components, the prohibition on corporate use may not be enforceable for those components or for derivative works that are required to be distributed under the copyleft license.
+- If you intend to get legal certainty about combined use, consult counsel. When in doubt, treat third-party licenced files as governed by their own licenses and follow their obligations (attribution, source availability, copyleft terms, patent clauses, etc.).


### PR DESCRIPTION
Short description: NCUL-1.0 (Non-Corporate Use License) permits use, modification, and distribution for non-corporate entities; commercial/corporate use is restricted.\n\nFiles included: json/details/NCUL-1.0.json and src/NCUL-1.0.txt (SPDX metadata and full license text).\n\nRepository-local references:\n- file:///home/natalie/Projects/browsers/LICENSE-NONCORP.txt\n- file:///home/natalie/Projects/browsers/LICENSE-APPLICABILITY.md\n- file:///home/natalie/Projects/browsers/LICENSE_REGISTRATION.md\n\nNotes: This is a custom license (not OSI-approved). Compatibility caveats: may be incompatible with strong copyleft/viral licenses for redistribution by corporate entities. Please advise on any required SPDX fields or validation requirements. The SPDX JSON is included at json/details/NCUL-1.0.json in this PR.